### PR TITLE
CLI-60: Suppress release link auto-open when --yes-always is set

### DIFF
--- a/cecli/main.py
+++ b/cecli/main.py
@@ -1441,7 +1441,10 @@ async def main_async(
         pre_init_io.tool_output()
         webbrowser.open(urls.release_notes)
         return await graceful_exit(coder)
-    elif args.show_release_notes is None and is_first_run:
+    elif args.show_release_notes is None and is_first_run and not args.yes_always:
+        # Suppress the first-run release-notes prompt when --yes-always is set,
+        # so automated/headless runs don't have the browser hijacked by an
+        # auto-confirmed offer_url. Explicit --show-release-notes still opens.
         pre_init_io.tool_output()
         await pre_init_io.offer_url(
             urls.release_notes,

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -372,6 +372,38 @@ def test_main_exit_calls_version_check(dummy_io, git_temp_dir, mocker):
     mock_input_output.assert_called_once()
 
 
+def test_suppress_release_notes_prompt_with_yes_always(dummy_io, git_temp_dir, mocker):
+    mock_input_output = mocker.patch("cecli.io.InputOutput")
+    mock_input_output.return_value.confirm_ask = AsyncMock(return_value=True)
+    mock_input_output.return_value.offer_url = AsyncMock()
+    mocker.patch("cecli.main.is_first_run_of_new_version", return_value=True)
+    
+    main(["--exit", "--yes-always"], **dummy_io)
+    mock_input_output.return_value.offer_url.assert_not_called()
+
+
+def test_shows_release_notes_prompt_on_first_run(dummy_io, git_temp_dir, mocker):
+    mock_input_output = mocker.patch("cecli.io.InputOutput")
+    mock_input_output.return_value.confirm_ask = AsyncMock(return_value=True)
+    mock_input_output.return_value.offer_url = AsyncMock()
+    mocker.patch("cecli.main.is_first_run_of_new_version", return_value=True)
+    
+    main(["--exit"], **dummy_io)
+    mock_input_output.return_value.offer_url.assert_called_once()
+
+
+def test_explicit_show_release_notes_with_yes_always(dummy_io, git_temp_dir, mocker):
+    mock_input_output = mocker.patch("cecli.io.InputOutput")
+    mock_input_output.return_value.confirm_ask = AsyncMock(return_value=True)
+    mock_input_output.return_value.offer_url = AsyncMock()
+    mocker.patch("cecli.main.is_first_run_of_new_version", return_value=True)
+    mocker.patch("webbrowser.open")
+    
+    main(["--exit", "--yes-always", "--show-release-notes"], **dummy_io)
+    # The explicit --show-release-notes code path uses webbrowser.open directly, not offer_url
+    mock_input_output.return_value.offer_url.assert_not_called()
+
+
 def test_main_message_adds_to_input_history(dummy_io, mocker):
     mocker.patch("cecli.coders.base_coder.Coder.run")
     MockInputOutput = mocker.patch("cecli.io.InputOutput", autospec=True)


### PR DESCRIPTION
This PR addresses the issue where the release notes link automatically opens in the browser when the `--yes-always` flag is set.

## Problem
When users run cecli with `--yes-always`, cecli still auto-opens the release link in the browser on startup due to auto-answering the first-run prompt. This causes unexpected browser tabs to open in headless/automated contexts.

## Solution
Modified `cecli/main.py`: Updated the `main_async` function to skip the automated browser opening logic if `args.yes_always` is True. This ensures that automated testing environments or non-interactive sessions are not interrupted by unexpected browser launches.

Specifically changed:
- Line ~1700: `elif args.show_release_notes is None and is_first_run:` 
  to `elif args.show_release_notes is None and is_first_run and not args.yes_always:`

## Verification
- Verified that running `cecli --yes-always` no longer triggers the browser.
- Verified that the standard behavior (without `--yes-always`) still opens the link as expected.
- Verified that explicit `--show-release-notes` still opens the link.

This respects the non-interactive intent of the `--yes-always` flag by skipping the release notes `offer_url` prompt when the user has specified "always yes".