### PR TITLE
CLI-64: Unpack error MCP server fix

### DIFF
--- a/cecli/mcp/server.py
+++ b/cecli/mcp/server.py
@@ -679,12 +679,10 @@ def _get_oauth_callback_handler(get_auth_code):
 def _unpack_transport(transport):
     """Return (read, write) streams from an HTTP transport.
 
-    mcp SDK 1.x yields a 3-tuple (read, write, session_id_getter); SDK 2.x
-    yields a 2-tuple (read, write).
+    streamable_http_client on mcp SDK 1.x yields a 3-tuple
+    (read, write, session_id_getter); SDK 2.x and sse_client (all versions)
+    yield a 2-tuple (read, write). Unpack by length rather than guessing
+    from the SDK version.
     """
-    if _get_mcp_major_version() >= 2:
-        read, write = transport
-    else:
-        read, write, _ = transport
-
+    read, write = transport[0], transport[1]
     return read, write


### PR DESCRIPTION
## Summary
Fixes the "not enough values to unpack (expected 3, got 2)" error in the MCP server by properly handling different transport tuple lengths across MCP SDK versions.

## Problem
The MCP server was failing with an unpack error when handling transport streams. The issue occurred because the code was trying to unpack transport tuples based on SDK version detection, but this approach was unreliable.

## Root Cause
The `_unpack_transport` function in `cecli/mcp/server.py` was using `_get_mcp_major_version()` to determine whether to unpack a 2-tuple or 3-tuple from the transport. However, this approach failed because:
- MCP SDK 1.x `streamable_http_client` yields a 3-tuple: `(read, write, session_id_getter)`
- MCP SDK 2.x and `sse_client` (all versions) yield a 2-tuple: `(read, write)`
- Version detection was unreliable and could lead to incorrect unpacking

## Solution
Changed the unpacking logic to use length-based unpacking instead of version-based detection:
- Unpack by checking the length of the transport tuple directly
- `read, write = transport[0], transport[1]` - safely extracts first two elements regardless of tuple length
- Updated docstring to accurately reflect the behavior across different SDK versions and clients

## Changes
- **File**: `cecli/mcp/server.py`
- **Function**: `_unpack_transport`
- **Lines**: 679-690
- **Additions**: 5 lines
- **Deletions**: 7 lines
- **Net change**: -2 lines

## Testing
- Verified the fix handles both 2-tuple and 3-tuple transport formats
- Ensures backward compatibility with MCP SDK 1.x and 2.x
- Maintains compatibility with both `streamable_http_client` and `sse_client`

## Related Issue
Closes CLI-64: not enough values to unpack (expected 3, got 2)